### PR TITLE
Add the appleboy gh action to scp docs to the droplet.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,36 +9,16 @@ on:
 jobs:
   build_and_push:
     runs-on: ubuntu-latests
-    env:
-      FIRST_NAME: Mona
     steps:
       - name: Checkout files
         uses: actions/checkout@v3
-      - name: Create IMAGES_TAG_CLI env var
-        run: export IMAGES_TAG_CLI=$(echo $GITHUB_SHA | head -c7)
-      - name: Create TEST_ENV_VAR env var
-        run: export TEST_ENV_VAR="hello test env var"
-      - name: Another test
-        run: export GIT_PR_SHA_SHORT=${GITHUB_SHA:0:10}
-      - name: Another test
-        run: export GIT_PR_SHA_NOT_SHORT="${{ github.sha }}"
-      - name: Print IMAGES_TAG_CLI
-        run: echo $IMAGES_TAG_CLI
-      - name: Print TEST_ENV_VAR
-        run: echo $TEST_ENV_VAR
-      - name: Print GIT_PR_SHA_SHORT
-        run: echo $GIT_PR_SHA_SHORT
-      - name: Print GIT_PR_SHA_NOT_SHORT
-        run: echo $GIT_PR_SHA_NOT_SHORT
-      - name: Print FIRST_NAME
-        run: echo $FIRST_NAME
       - name: Create deploy_meta.env
         run: |
           echo \
           "GITHUB_SHA="$GITHUB_SHA \
           "\nGITHUB_RUN_ID="$GITHUB_RUN_ID \
           "\nGITHUB_RUN_NUMBER="$GITHUB_RUN_NUMBER \
-          "\nIMAGES_TAG="$IMAGES_TAG \
+          "\nIMAGES_TAG="$(echo $GITHUB_SHA | head -c7) \
           > deploy_meta.env
       - name: Build images
         run: |
@@ -63,26 +43,25 @@ jobs:
       - name: Copy file via ssh password
         uses: appleboy/scp-action@master
         with:
-          host: ${{ secrets.HOST }}
-          username: ${{ secrets.USERNAME }}
-          password: ${{ secrets.PASSWORD }}
-          port: ${{ secrets.PORT }}
-          source: "tests/a.txt,tests/b.txt"
-          target: "test"
+          host: ${{ secrets.SSH_KNOWN_HOSTS }}
+          username: ${{ secrets.SSH_USERNAME }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          source: "docker-compose.production.yml,deploy_meta.env,config/digitalocean.env"
+          target: "vote_the_news"
+          rm: true
       - name: Execute remote ssh commands using ssh key
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.SSH_KNOWN_HOSTS }}
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          envs: GITHUB_SHA
           script: |
             date >> timestamp.txt
             cd vote_the_news
-            git pull https://github.com/FelipeKha/vote_the_news.git
-            echo "IMAGES_TAG="$GITHUB_SHA | head -c18 > ~/vote_the_news/images_tag.env
             docker ps -aq | xargs docker stop | xargs docker rm
             docker images -a | xargs docker rmi
-            docker compose -f docker-compose.production.yml --env-file images_tag.env up -d
+            docker compose -f docker-compose.production.yml --env-file deploy_meta.env up -d
 
-            export $(grep -v '^#' .env | xargs -d '\n')
+# git pull https://github.com/FelipeKha/vote_the_news.git
+# echo "IMAGES_TAG="$GITHUB_SHA | head -c18 > ~/vote_the_news/images_tag.env
+# export $(grep -v '^#' deploy_meta.env | xargs -d '\n')


### PR DESCRIPTION
Remove the git pull instruction in the droplet, and replace it with a gh action that ssh to the droplet to scp required files to pull the images from dockerhub and launch the containers on the droplet.